### PR TITLE
add repository to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.2.1"
 edition = "2021"
 description = "A rust macro allowing to fill arrays with an expression"
 license = "MIT"
+repository = "https://github.com/Galitan-dev/fill-array"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
to allow https://crates.io/ , https://lib.rs/ and https://rust-digger.code-maven.com/ to link to it